### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,4 +382,4 @@ Hdiv is released under version 2.0 of the [Apache License](http://www.apache.org
 
 ## Profiler
 JProfiler is kindly supporting Hdiv open source project with its full-featured Java Profiler.
-Take a look at JProfiler's leading software products: [Java Profiler](http://www.ej-technologies.com/products/jprofiler/overview.html)
+Take a look at JProfiler's leading software products: [Java Profiler](http://www.ej-technologies.com/products/jprofiler/overview.html


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
